### PR TITLE
Add attributes as last param on twitch messages

### DIFF
--- a/addons/godot-twicil/godot_twicil.gd
+++ b/addons/godot-twicil/godot_twicil.gd
@@ -50,213 +50,213 @@ var user_emotes_queue := Dictionary()
 
 # Public methods
 func connect_to_twitch_chat():
-	.connect_to_host(TWITCH_IRC_CHAT_HOST, TWITCH_IRC_CHAT_PORT)
+    .connect_to_host(TWITCH_IRC_CHAT_HOST, TWITCH_IRC_CHAT_PORT)
 
 func connect_to_channel(channel, client_id, password, nickname, realname=''):
-	_connect_to(
-		channel,
-		nickname,
-		nickname if realname == '' else realname,
-		password,
-		client_id
-	)
+    _connect_to(
+        channel,
+        nickname,
+        nickname if realname == '' else realname,
+        password,
+        client_id
+    )
 
-	bttv_emotes_cache.init_emotes(curr_channel)
+    bttv_emotes_cache.init_emotes(curr_channel)
 
-	twitch_api_wrapper.set_credentials(client_id, password)
+    twitch_api_wrapper.set_credentials(client_id, password)
 
 func _connect_to(channel, nickname, realname, password, client_id):
-	.send_command('PASS %s' % password)
+    .send_command('PASS %s' % password)
 
-	.send_command('NICK ' +  nickname)
+    .send_command('NICK ' +  nickname)
 
-	.send_command(str('USER ', client_id, ' ', _host, ' bla:', realname))
-	.send_command('JOIN #' + channel)
+    .send_command(str('USER ', client_id, ' ', _host, ' bla:', realname))
+    .send_command('JOIN #' + channel)
 
-	.send_command("CAP REQ :twitch.tv/tags twitch.tv/commands twitch.tv/membership")
+    .send_command("CAP REQ :twitch.tv/tags twitch.tv/commands twitch.tv/membership")
 
-	curr_channel = channel
+    curr_channel = channel
 
 func send_message(text):
-	.send_command(str('PRIVMSG #', curr_channel, ' :', text))
+    .send_command(str('PRIVMSG #', curr_channel, ' :', text))
 
 func send_whisper(recepient, text):
-	send_message(str('/w ', recepient, ' ', text))
+    send_message(str('/w ', recepient, ' ', text))
 
 func request_twitch_emote(user_name: String, id: int) -> void:
-	if not user_emotes_queue.has(id):
-		user_emotes_queue[id] = []
+    if not user_emotes_queue.has(id):
+        user_emotes_queue[id] = []
 
-	user_emotes_queue[id].append(user_name)
+    user_emotes_queue[id].append(user_name)
 
-	twitch_emotes_cache.get_emote(id)
+    twitch_emotes_cache.get_emote(id)
 
 func request_bttv_emote(user_name: String, code: String) -> void:
-	var id: String = bttv_emotes_cache.available_emotes.get(code)
+    var id: String = bttv_emotes_cache.available_emotes.get(code)
 
-	if not user_emotes_queue.has(id):
-		user_emotes_queue[id] = []
+    if not user_emotes_queue.has(id):
+        user_emotes_queue[id] = []
 
-	user_emotes_queue[id].append(user_name)
+    user_emotes_queue[id].append(user_name)
 
-	bttv_emotes_cache.get_emote(code)
+    bttv_emotes_cache.get_emote(code)
 
 func request_ffz_emote(user_name: String, code: String) -> void:
-	var id: String = ffz_emotes_cache.available_emotes.get(code, {}).get('id', '')
+    var id: String = ffz_emotes_cache.available_emotes.get(code, {}).get('id', '')
 
-	if not user_emotes_queue.has(id):
-		user_emotes_queue[id] = []
+    if not user_emotes_queue.has(id):
+        user_emotes_queue[id] = []
 
-	user_emotes_queue[id].append(user_name)
+    user_emotes_queue[id].append(user_name)
 
-	ffz_emotes_cache.get_emote(code)
+    ffz_emotes_cache.get_emote(code)
 
 func request_emote_from(emotes: Array, user_name: String, index: int) -> void:
-	if emotes.empty():
-		return
+    if emotes.empty():
+        return
 
-	var emote = emotes[index]
+    var emote = emotes[index]
 
-	if emote.get('type') == TwitchMessage.EmoteType.TWITCH:
-		var emote_id := int(emote.get('id'))
-		request_twitch_emote(user_name, emote_id)
+    if emote.get('type') == TwitchMessage.EmoteType.TWITCH:
+        var emote_id := int(emote.get('id'))
+        request_twitch_emote(user_name, emote_id)
 
-	elif emote.get('type') == TwitchMessage.EmoteType.BTTV:
-		var emote_code := emote.get('code') as String
-		request_bttv_emote(user_name, emote_code)
+    elif emote.get('type') == TwitchMessage.EmoteType.BTTV:
+        var emote_code := emote.get('code') as String
+        request_bttv_emote(user_name, emote_code)
 
-	elif emote.get('type') == TwitchMessage.EmoteType.FFZ:
-		var emote_code := emote.get('code') as String
-		request_ffz_emote(user_name, emote_code)
+    elif emote.get('type') == TwitchMessage.EmoteType.FFZ:
+        var emote_code := emote.get('code') as String
+        request_ffz_emote(user_name, emote_code)
 
 # Private methods
 func __init_emotes_caches() -> void:
-	twitch_emotes_cache = TwitchEmotesCache.new()
-	add_child(twitch_emotes_cache)
+    twitch_emotes_cache = TwitchEmotesCache.new()
+    add_child(twitch_emotes_cache)
 
-	bttv_emotes_cache = BttvEmotesCache.new()
-	add_child(bttv_emotes_cache)
+    bttv_emotes_cache = BttvEmotesCache.new()
+    add_child(bttv_emotes_cache)
 
-	ffz_emotes_cache = FfzEmotesCache.new()
-	add_child(ffz_emotes_cache)
+    ffz_emotes_cache = FfzEmotesCache.new()
+    add_child(ffz_emotes_cache)
 
 func __init_twitch_api() -> void:
-	twitch_api_wrapper = TwitchApiWrapper.new(http_request_queue, '')
+    twitch_api_wrapper = TwitchApiWrapper.new(http_request_queue, '')
 
 func __connect_signals():
-	connect("message_recieved", commands, "_on_message_recieved")
-	connect("response_recieved", self, "_on_response_recieved")
-	connect("http_response_recieved", self, "_on_http_response_recieved")
+    connect("message_recieved", commands, "_on_message_recieved")
+    connect("response_recieved", self, "_on_response_recieved")
+    connect("http_response_recieved", self, "_on_http_response_recieved")
 
-	twitch_emotes_cache.connect("emote_retrieved", self, "_on_emote_retrieved")
-	bttv_emotes_cache.connect("emote_retrieved", self, "_on_emote_retrieved")
-	ffz_emotes_cache.connect("emote_retrieved", self, "_on_emote_retrieved")
+    twitch_emotes_cache.connect("emote_retrieved", self, "_on_emote_retrieved")
+    bttv_emotes_cache.connect("emote_retrieved", self, "_on_emote_retrieved")
+    ffz_emotes_cache.connect("emote_retrieved", self, "_on_emote_retrieved")
 
-	twitch_api_wrapper.connect("api_user_info", self, "_on_twitch_api_api_user_info")
+    twitch_api_wrapper.connect("api_user_info", self, "_on_twitch_api_api_user_info")
 
 func __parse(string: String) -> TwitchIrcServerMessage:
-	var args = []
-	var twitch_prefix = ''
-	var prefix = ''
-	var trailing = []
-	var command
+    var args = []
+    var twitch_prefix = ''
+    var prefix = ''
+    var trailing = []
+    var command
 
-	if string == null:
-		return TwitchIrcServerMessage.new('', '','', [])
+    if string == null:
+        return TwitchIrcServerMessage.new('', '','', [])
 
-	if string.substr(0, 1) == '@':
-		var temp = tools.split_string(string.substr(1, string.length() - 1), ' ', 1)
-		twitch_prefix = temp[0]
-		string = temp[1]
+    if string.substr(0, 1) == '@':
+        var temp = tools.split_string(string.substr(1, string.length() - 1), ' ', 1)
+        twitch_prefix = temp[0]
+        string = temp[1]
 
-	if string.substr(0, 1) == ':':
-		var temp = tools.split_string(string.substr(1, string.length() - 1), ' ', 1)
-		prefix = temp[0]
-		string = temp[1]
+    if string.substr(0, 1) == ':':
+        var temp = tools.split_string(string.substr(1, string.length() - 1), ' ', 1)
+        prefix = temp[0]
+        string = temp[1]
 
-	if string.find(' :') != -1:
-		var temp = tools.split_string(string, ' :', 1)
-		string = temp[0]
-		trailing = temp[1]
+    if string.find(' :') != -1:
+        var temp = tools.split_string(string, ' :', 1)
+        string = temp[0]
+        trailing = temp[1]
 
-		args = tools.split_string(string, [' ', '\t', '\n'])
+        args = tools.split_string(string, [' ', '\t', '\n'])
 
-		args.append(trailing)
-	else:
-		args = tools.split_string(string, [' ', '\t', '\n'])
+        args.append(trailing)
+    else:
+        args = tools.split_string(string, [' ', '\t', '\n'])
 
-	command = args[0]
-	args.pop_front()
+    command = args[0]
+    args.pop_front()
 
-	return TwitchIrcServerMessage.new(twitch_prefix, prefix, command, args)
+    return TwitchIrcServerMessage.new(twitch_prefix, prefix, command, args)
 
 func __parse_attrs(message_prefix):
-	var attrs = {}
-	var raw_attrs = message_prefix.split(";")
-	for raw_attr in raw_attrs:
-		var key_value = raw_attr.split("=")
-		var key = key_value[0]
-		var value = null
-		if key_value.size() > 1:
-			value = key_value[1]
-		attrs[key] = value
-	return attrs
+    var attrs = {}
+    var raw_attrs = message_prefix.split(";")
+    for raw_attr in raw_attrs:
+        var key_value = raw_attr.split("=")
+        var key = key_value[0]
+        var value = null
+        if key_value.size() > 1:
+            value = key_value[1]
+        attrs[key] = value
+    return attrs
 
 # Hooks
 func _ready():
-	__init_twitch_api()
-	__init_emotes_caches()
-	__connect_signals()
+    __init_twitch_api()
+    __init_emotes_caches()
+    __connect_signals()
 
 
 # Events
 func _on_response_recieved(response):
-	emit_signal("raw_response_recieved", response)
+    emit_signal("raw_response_recieved", response)
 
-	for single_response in response.split('\n', false):
-		single_response = __parse(single_response.strip_edges(false))
+    for single_response in response.split('\n', false):
+        single_response = __parse(single_response.strip_edges(false))
 
-		# Ping-Pong with server to let it know we're alive
-		if single_response.command == irc_commands[IRCCommands.PING]:
-			.send_command(str(irc_commands[IRCCommands.PONG], ' ', single_response.params[0]))
+        # Ping-Pong with server to let it know we're alive
+        if single_response.command == irc_commands[IRCCommands.PING]:
+            .send_command(str(irc_commands[IRCCommands.PONG], ' ', single_response.params[0]))
 
-		# Message received
-		elif single_response.command == irc_commands[IRCCommands.PRIVMSG]:
-			var attrs = __parse_attrs(single_response.message_prefix)
-			var twitch_message: TwitchMessage = TwitchMessage.new(
-				single_response,
-				bttv_emotes_cache.available_emotes,
-				ffz_emotes_cache.available_emotes,
-				attrs
-			)
+        # Message received
+        elif single_response.command == irc_commands[IRCCommands.PRIVMSG]:
+            var attrs = __parse_attrs(single_response.message_prefix)
+            var twitch_message: TwitchMessage = TwitchMessage.new(
+                single_response,
+                bttv_emotes_cache.available_emotes,
+                ffz_emotes_cache.available_emotes,
+                attrs
+            )
 
-			emit_signal(
-				"message_recieved",
-				twitch_message.chat_message.name,
-				twitch_message.chat_message.text,
-				twitch_message.emotes,
-				twitch_message.attrs
-			)
+            emit_signal(
+                "message_recieved",
+                twitch_message.chat_message.name,
+                twitch_message.chat_message.text,
+                twitch_message.emotes,
+                twitch_message.attrs
+            )
 
-		elif single_response.command == irc_commands[IRCCommands.JOIN]:
-			var user_name = MessageWrapper.get_sender_name(single_response)
-			chat_list.add_user(user_name)
-			._log(str(user_name, " has joined chat"))
-			emit_signal("user_appeared", user_name)
+        elif single_response.command == irc_commands[IRCCommands.JOIN]:
+            var user_name = MessageWrapper.get_sender_name(single_response)
+            chat_list.add_user(user_name)
+            ._log(str(user_name, " has joined chat"))
+            emit_signal("user_appeared", user_name)
 
-		elif single_response.command == irc_commands[IRCCommands.PART]:
-			var user_name = MessageWrapper.get_sender_name(single_response)
-			chat_list.remove_user(user_name)
-			._log(str(user_name, " has left chat"))
-			emit_signal("user_disappeared", user_name)
+        elif single_response.command == irc_commands[IRCCommands.PART]:
+            var user_name = MessageWrapper.get_sender_name(single_response)
+            chat_list.remove_user(user_name)
+            ._log(str(user_name, " has left chat"))
+            emit_signal("user_disappeared", user_name)
 
 func _on_emote_retrieved(emote_reference: Reference) -> void:
-	var emote_id: String = emote_reference.id
-	var user: String = (user_emotes_queue.get(emote_id, []) as Array).pop_front()
+    var emote_id: String = emote_reference.id
+    var user: String = (user_emotes_queue.get(emote_id, []) as Array).pop_front()
 
-	emit_signal("emote_recieved", user, emote_reference)
+    emit_signal("emote_recieved", user, emote_reference)
 
 func _on_twitch_api_api_user_info(data):
-	var user_id := str(data.get('data', [{}])[0].get('id', 0))
+    var user_id := str(data.get('data', [{}])[0].get('id', 0))
 
-	ffz_emotes_cache.init_emotes(user_id)
+    ffz_emotes_cache.init_emotes(user_id)

--- a/addons/godot-twicil/godot_twicil.gd
+++ b/addons/godot-twicil/godot_twicil.gd
@@ -4,7 +4,7 @@ class_name TwiCIL
 signal raw_response_recieved(response)
 signal user_appeared(user)
 signal user_disappeared(user)
-signal message_recieved(sender, text, emotes)
+signal message_recieved(sender, text, emotes, attr)
 
 signal emote_recieved(user, emote_reference)
 
@@ -50,199 +50,213 @@ var user_emotes_queue := Dictionary()
 
 # Public methods
 func connect_to_twitch_chat():
-    .connect_to_host(TWITCH_IRC_CHAT_HOST, TWITCH_IRC_CHAT_PORT)
+	.connect_to_host(TWITCH_IRC_CHAT_HOST, TWITCH_IRC_CHAT_PORT)
 
 func connect_to_channel(channel, client_id, password, nickname, realname=''):
-    _connect_to(
-        channel,
-        nickname,
-        nickname if realname == '' else realname,
-        password,
-        client_id
-    )
+	_connect_to(
+		channel,
+		nickname,
+		nickname if realname == '' else realname,
+		password,
+		client_id
+	)
 
-    bttv_emotes_cache.init_emotes(curr_channel)
+	bttv_emotes_cache.init_emotes(curr_channel)
 
-    twitch_api_wrapper.set_credentials(client_id, password)
+	twitch_api_wrapper.set_credentials(client_id, password)
 
 func _connect_to(channel, nickname, realname, password, client_id):
-    .send_command('PASS %s' % password)
+	.send_command('PASS %s' % password)
 
-    .send_command('NICK ' +  nickname)
+	.send_command('NICK ' +  nickname)
 
-    .send_command(str('USER ', client_id, ' ', _host, ' bla:', realname))
-    .send_command('JOIN #' + channel)
+	.send_command(str('USER ', client_id, ' ', _host, ' bla:', realname))
+	.send_command('JOIN #' + channel)
 
-    .send_command("CAP REQ :twitch.tv/tags twitch.tv/commands twitch.tv/membership")
+	.send_command("CAP REQ :twitch.tv/tags twitch.tv/commands twitch.tv/membership")
 
-    curr_channel = channel
+	curr_channel = channel
 
 func send_message(text):
-    .send_command(str('PRIVMSG #', curr_channel, ' :', text))
+	.send_command(str('PRIVMSG #', curr_channel, ' :', text))
 
 func send_whisper(recepient, text):
-    send_message(str('/w ', recepient, ' ', text))
+	send_message(str('/w ', recepient, ' ', text))
 
 func request_twitch_emote(user_name: String, id: int) -> void:
-    if not user_emotes_queue.has(id):
-        user_emotes_queue[id] = []
+	if not user_emotes_queue.has(id):
+		user_emotes_queue[id] = []
 
-    user_emotes_queue[id].append(user_name)
+	user_emotes_queue[id].append(user_name)
 
-    twitch_emotes_cache.get_emote(id)
+	twitch_emotes_cache.get_emote(id)
 
 func request_bttv_emote(user_name: String, code: String) -> void:
-    var id: String = bttv_emotes_cache.available_emotes.get(code)
+	var id: String = bttv_emotes_cache.available_emotes.get(code)
 
-    if not user_emotes_queue.has(id):
-        user_emotes_queue[id] = []
+	if not user_emotes_queue.has(id):
+		user_emotes_queue[id] = []
 
-    user_emotes_queue[id].append(user_name)
+	user_emotes_queue[id].append(user_name)
 
-    bttv_emotes_cache.get_emote(code)
+	bttv_emotes_cache.get_emote(code)
 
 func request_ffz_emote(user_name: String, code: String) -> void:
-    var id: String = ffz_emotes_cache.available_emotes.get(code, {}).get('id', '')
+	var id: String = ffz_emotes_cache.available_emotes.get(code, {}).get('id', '')
 
-    if not user_emotes_queue.has(id):
-        user_emotes_queue[id] = []
+	if not user_emotes_queue.has(id):
+		user_emotes_queue[id] = []
 
-    user_emotes_queue[id].append(user_name)
+	user_emotes_queue[id].append(user_name)
 
-    ffz_emotes_cache.get_emote(code)
+	ffz_emotes_cache.get_emote(code)
 
 func request_emote_from(emotes: Array, user_name: String, index: int) -> void:
-    if emotes.empty():
-        return
+	if emotes.empty():
+		return
 
-    var emote = emotes[index]
+	var emote = emotes[index]
 
-    if emote.get('type') == TwitchMessage.EmoteType.TWITCH:
-        var emote_id := int(emote.get('id'))
-        request_twitch_emote(user_name, emote_id)
+	if emote.get('type') == TwitchMessage.EmoteType.TWITCH:
+		var emote_id := int(emote.get('id'))
+		request_twitch_emote(user_name, emote_id)
 
-    elif emote.get('type') == TwitchMessage.EmoteType.BTTV:
-        var emote_code := emote.get('code') as String
-        request_bttv_emote(user_name, emote_code)
+	elif emote.get('type') == TwitchMessage.EmoteType.BTTV:
+		var emote_code := emote.get('code') as String
+		request_bttv_emote(user_name, emote_code)
 
-    elif emote.get('type') == TwitchMessage.EmoteType.FFZ:
-        var emote_code := emote.get('code') as String
-        request_ffz_emote(user_name, emote_code)
+	elif emote.get('type') == TwitchMessage.EmoteType.FFZ:
+		var emote_code := emote.get('code') as String
+		request_ffz_emote(user_name, emote_code)
 
 # Private methods
 func __init_emotes_caches() -> void:
-    twitch_emotes_cache = TwitchEmotesCache.new()
-    add_child(twitch_emotes_cache)
+	twitch_emotes_cache = TwitchEmotesCache.new()
+	add_child(twitch_emotes_cache)
 
-    bttv_emotes_cache = BttvEmotesCache.new()
-    add_child(bttv_emotes_cache)
+	bttv_emotes_cache = BttvEmotesCache.new()
+	add_child(bttv_emotes_cache)
 
-    ffz_emotes_cache = FfzEmotesCache.new()
-    add_child(ffz_emotes_cache)
+	ffz_emotes_cache = FfzEmotesCache.new()
+	add_child(ffz_emotes_cache)
 
 func __init_twitch_api() -> void:
-    twitch_api_wrapper = TwitchApiWrapper.new(http_request_queue, '')
+	twitch_api_wrapper = TwitchApiWrapper.new(http_request_queue, '')
 
 func __connect_signals():
-    connect("message_recieved", commands, "_on_message_recieved")
-    connect("response_recieved", self, "_on_response_recieved")
-    connect("http_response_recieved", self, "_on_http_response_recieved")
+	connect("message_recieved", commands, "_on_message_recieved")
+	connect("response_recieved", self, "_on_response_recieved")
+	connect("http_response_recieved", self, "_on_http_response_recieved")
 
-    twitch_emotes_cache.connect("emote_retrieved", self, "_on_emote_retrieved")
-    bttv_emotes_cache.connect("emote_retrieved", self, "_on_emote_retrieved")
-    ffz_emotes_cache.connect("emote_retrieved", self, "_on_emote_retrieved")
+	twitch_emotes_cache.connect("emote_retrieved", self, "_on_emote_retrieved")
+	bttv_emotes_cache.connect("emote_retrieved", self, "_on_emote_retrieved")
+	ffz_emotes_cache.connect("emote_retrieved", self, "_on_emote_retrieved")
 
-    twitch_api_wrapper.connect("api_user_info", self, "_on_twitch_api_api_user_info")
+	twitch_api_wrapper.connect("api_user_info", self, "_on_twitch_api_api_user_info")
 
 func __parse(string: String) -> TwitchIrcServerMessage:
-    var args = []
-    var twitch_prefix = ''
-    var prefix = ''
-    var trailing = []
-    var command
+	var args = []
+	var twitch_prefix = ''
+	var prefix = ''
+	var trailing = []
+	var command
 
-    if string == null:
-        return TwitchIrcServerMessage.new('', '','', [])
+	if string == null:
+		return TwitchIrcServerMessage.new('', '','', [])
 
-    if string.substr(0, 1) == '@':
-        var temp = tools.split_string(string.substr(1, string.length() - 1), ' ', 1)
-        twitch_prefix = temp[0]
-        string = temp[1]
+	if string.substr(0, 1) == '@':
+		var temp = tools.split_string(string.substr(1, string.length() - 1), ' ', 1)
+		twitch_prefix = temp[0]
+		string = temp[1]
 
-    if string.substr(0, 1) == ':':
-        var temp = tools.split_string(string.substr(1, string.length() - 1), ' ', 1)
-        prefix = temp[0]
-        string = temp[1]
+	if string.substr(0, 1) == ':':
+		var temp = tools.split_string(string.substr(1, string.length() - 1), ' ', 1)
+		prefix = temp[0]
+		string = temp[1]
 
-    if string.find(' :') != -1:
-        var temp = tools.split_string(string, ' :', 1)
-        string = temp[0]
-        trailing = temp[1]
+	if string.find(' :') != -1:
+		var temp = tools.split_string(string, ' :', 1)
+		string = temp[0]
+		trailing = temp[1]
 
-        args = tools.split_string(string, [' ', '\t', '\n'])
+		args = tools.split_string(string, [' ', '\t', '\n'])
 
-        args.append(trailing)
-    else:
-        args = tools.split_string(string, [' ', '\t', '\n'])
+		args.append(trailing)
+	else:
+		args = tools.split_string(string, [' ', '\t', '\n'])
 
-    command = args[0]
-    args.pop_front()
+	command = args[0]
+	args.pop_front()
 
-    return TwitchIrcServerMessage.new(twitch_prefix, prefix, command, args)
+	return TwitchIrcServerMessage.new(twitch_prefix, prefix, command, args)
 
+func __parse_attrs(message_prefix):
+	var attrs = {}
+	var raw_attrs = message_prefix.split(";")
+	for raw_attr in raw_attrs:
+		var key_value = raw_attr.split("=")
+		var key = key_value[0]
+		var value = null
+		if key_value.size() > 1:
+			value = key_value[1]
+		attrs[key] = value
+	return attrs
 
 # Hooks
 func _ready():
-    __init_twitch_api()
-    __init_emotes_caches()
-    __connect_signals()
+	__init_twitch_api()
+	__init_emotes_caches()
+	__connect_signals()
 
 
 # Events
 func _on_response_recieved(response):
-    emit_signal("raw_response_recieved", response)
+	emit_signal("raw_response_recieved", response)
 
-    for single_response in response.split('\n', false):
-        single_response = __parse(single_response.strip_edges(false))
+	for single_response in response.split('\n', false):
+		single_response = __parse(single_response.strip_edges(false))
 
-        # Ping-Pong with server to let it know we're alive
-        if single_response.command == irc_commands[IRCCommands.PING]:
-            .send_command(str(irc_commands[IRCCommands.PONG], ' ', single_response.params[0]))
+		# Ping-Pong with server to let it know we're alive
+		if single_response.command == irc_commands[IRCCommands.PING]:
+			.send_command(str(irc_commands[IRCCommands.PONG], ' ', single_response.params[0]))
 
-        # Message received
-        elif single_response.command == irc_commands[IRCCommands.PRIVMSG]:
-            var twitch_message: TwitchMessage = TwitchMessage.new(
-                single_response,
-                bttv_emotes_cache.available_emotes,
-                ffz_emotes_cache.available_emotes
-            )
+		# Message received
+		elif single_response.command == irc_commands[IRCCommands.PRIVMSG]:
+			var attrs = __parse_attrs(single_response.message_prefix)
+			var twitch_message: TwitchMessage = TwitchMessage.new(
+				single_response,
+				bttv_emotes_cache.available_emotes,
+				ffz_emotes_cache.available_emotes,
+				attrs
+			)
 
-            emit_signal(
-                "message_recieved",
-                twitch_message.chat_message.name,
-                twitch_message.chat_message.text,
-                twitch_message.emotes
-            )
+			emit_signal(
+				"message_recieved",
+				twitch_message.chat_message.name,
+				twitch_message.chat_message.text,
+				twitch_message.emotes,
+				twitch_message.attrs
+			)
 
-        elif single_response.command == irc_commands[IRCCommands.JOIN]:
-            var user_name = MessageWrapper.get_sender_name(single_response)
-            chat_list.add_user(user_name)
-            ._log(str(user_name, " has joined chat"))
-            emit_signal("user_appeared", user_name)
+		elif single_response.command == irc_commands[IRCCommands.JOIN]:
+			var user_name = MessageWrapper.get_sender_name(single_response)
+			chat_list.add_user(user_name)
+			._log(str(user_name, " has joined chat"))
+			emit_signal("user_appeared", user_name)
 
-        elif single_response.command == irc_commands[IRCCommands.PART]:
-            var user_name = MessageWrapper.get_sender_name(single_response)
-            chat_list.remove_user(user_name)
-            ._log(str(user_name, " has left chat"))
-            emit_signal("user_disappeared", user_name)
+		elif single_response.command == irc_commands[IRCCommands.PART]:
+			var user_name = MessageWrapper.get_sender_name(single_response)
+			chat_list.remove_user(user_name)
+			._log(str(user_name, " has left chat"))
+			emit_signal("user_disappeared", user_name)
 
 func _on_emote_retrieved(emote_reference: Reference) -> void:
-    var emote_id: String = emote_reference.id
-    var user: String = (user_emotes_queue.get(emote_id, []) as Array).pop_front()
+	var emote_id: String = emote_reference.id
+	var user: String = (user_emotes_queue.get(emote_id, []) as Array).pop_front()
 
-    emit_signal("emote_recieved", user, emote_reference)
+	emit_signal("emote_recieved", user, emote_reference)
 
 func _on_twitch_api_api_user_info(data):
-    var user_id := str(data.get('data', [{}])[0].get('id', 0))
+	var user_id := str(data.get('data', [{}])[0].get('id', 0))
 
-    ffz_emotes_cache.init_emotes(user_id)
+	ffz_emotes_cache.init_emotes(user_id)

--- a/addons/godot-twicil/helpers/interactive_commands.gd
+++ b/addons/godot-twicil/helpers/interactive_commands.gd
@@ -2,69 +2,69 @@ class_name InteractiveCommands
 
 
 class FuncRefEx extends FuncRef:
-	func _init(instance: Object, method: String):
-		.set_instance(instance)
-		.set_function(method)
+    func _init(instance: Object, method: String):
+        .set_instance(instance)
+        .set_function(method)
 
 class InteractiveCommand:
-	var func_ref: FuncRef
-	var params_count: int
-	var variable_params_count: int
+    var func_ref: FuncRef
+    var params_count: int
+    var variable_params_count: int
 
-	func _init(func_ref: FuncRef, params_count: int, variable_params_count: bool=false):
-		self.func_ref = func_ref
-		self.params_count = params_count
-		self.variable_params_count = variable_params_count
+    func _init(func_ref: FuncRef, params_count: int, variable_params_count: bool=false):
+        self.func_ref = func_ref
+        self.params_count = params_count
+        self.variable_params_count = variable_params_count
 
-	func call_command(params: Array) -> void:
-		func_ref.call_func(params)
+    func call_command(params: Array) -> void:
+        func_ref.call_func(params)
 
 var interactive_commands = {}
 
 # Public methods
 func add(
-	chat_command: String,
-	target: Object,
-	method_name: String,
-	params_count: int=1,
-	variable_params_count: bool=false
+    chat_command: String,
+    target: Object,
+    method_name: String,
+    params_count: int=1,
+    variable_params_count: bool=false
 ) -> void:
-	interactive_commands[chat_command] = InteractiveCommand.new(
-		FuncRefEx.new(target, method_name) as FuncRef, params_count, variable_params_count)
+    interactive_commands[chat_command] = InteractiveCommand.new(
+        FuncRefEx.new(target, method_name) as FuncRef, params_count, variable_params_count)
 
 func add_aliases(chat_command: String, new_aliases: Array) -> void:
-	if interactive_commands.has(chat_command):
-		for new_alias in new_aliases:
-			interactive_commands[new_alias] = interactive_commands[chat_command]
+    if interactive_commands.has(chat_command):
+        for new_alias in new_aliases:
+            interactive_commands[new_alias] = interactive_commands[chat_command]
 
 func remove(chat_command: String) -> void:
-	if interactive_commands.has(chat_command):
-		interactive_commands[chat_command]
-		interactive_commands.erase(chat_command)
+    if interactive_commands.has(chat_command):
+        interactive_commands[chat_command]
+        interactive_commands.erase(chat_command)
 
 # Events
 func _on_message_recieved(sender: String, text: String, emotes: Array, attrs: Dictionary) -> void:
-	var input_cmd: Array = text.split(' ')
+    var input_cmd: Array = text.split(' ')
 
-	for cmd in interactive_commands:
-		if input_cmd[0] == cmd:
+    for cmd in interactive_commands:
+        if input_cmd[0] == cmd:
 
-			if not interactive_commands[cmd].variable_params_count \
-			and input_cmd.size() - 1 < interactive_commands[cmd].params_count:
-				# TODO: React to invalid command params in chat
-				return
+            if not interactive_commands[cmd].variable_params_count \
+            and input_cmd.size() - 1 < interactive_commands[cmd].params_count:
+                # TODO: React to invalid command params in chat
+                return
 
-			var params: Array = [sender]
-			var params_count: int = clamp(
-				input_cmd.size() - 1,
-				0,
-				interactive_commands[cmd].params_count
-			)
+            var params: Array = [sender]
+            var params_count: int = clamp(
+                input_cmd.size() - 1,
+                0,
+                interactive_commands[cmd].params_count
+            )
 
-			if params_count >= 1:
-				for i in range(params_count):
-					params.append(input_cmd[i + 1])
+            if params_count >= 1:
+                for i in range(params_count):
+                    params.append(input_cmd[i + 1])
 
-			params.append(attrs)
+            params.append(attrs)
 
-			interactive_commands[cmd].call_command(params)
+            interactive_commands[cmd].call_command(params)

--- a/addons/godot-twicil/helpers/interactive_commands.gd
+++ b/addons/godot-twicil/helpers/interactive_commands.gd
@@ -2,67 +2,69 @@ class_name InteractiveCommands
 
 
 class FuncRefEx extends FuncRef:
-    func _init(instance: Object, method: String):
-        .set_instance(instance)
-        .set_function(method)
+	func _init(instance: Object, method: String):
+		.set_instance(instance)
+		.set_function(method)
 
 class InteractiveCommand:
-    var func_ref: FuncRef
-    var params_count: int
-    var variable_params_count: int
+	var func_ref: FuncRef
+	var params_count: int
+	var variable_params_count: int
 
-    func _init(func_ref: FuncRef, params_count: int, variable_params_count: bool=false):
-        self.func_ref = func_ref
-        self.params_count = params_count
-        self.variable_params_count = variable_params_count
+	func _init(func_ref: FuncRef, params_count: int, variable_params_count: bool=false):
+		self.func_ref = func_ref
+		self.params_count = params_count
+		self.variable_params_count = variable_params_count
 
-    func call_command(params: Array) -> void:
-        func_ref.call_func(params)
+	func call_command(params: Array) -> void:
+		func_ref.call_func(params)
 
 var interactive_commands = {}
 
 # Public methods
 func add(
-    chat_command: String,
-    target: Object,
-    method_name: String,
-    params_count: int=1,
-    variable_params_count: bool=false
+	chat_command: String,
+	target: Object,
+	method_name: String,
+	params_count: int=1,
+	variable_params_count: bool=false
 ) -> void:
-    interactive_commands[chat_command] = InteractiveCommand.new(
-        FuncRefEx.new(target, method_name) as FuncRef, params_count, variable_params_count)
+	interactive_commands[chat_command] = InteractiveCommand.new(
+		FuncRefEx.new(target, method_name) as FuncRef, params_count, variable_params_count)
 
 func add_aliases(chat_command: String, new_aliases: Array) -> void:
-    if interactive_commands.has(chat_command):
-        for new_alias in new_aliases:
-            interactive_commands[new_alias] = interactive_commands[chat_command]
+	if interactive_commands.has(chat_command):
+		for new_alias in new_aliases:
+			interactive_commands[new_alias] = interactive_commands[chat_command]
 
 func remove(chat_command: String) -> void:
-    if interactive_commands.has(chat_command):
-        interactive_commands[chat_command]
-        interactive_commands.erase(chat_command)
+	if interactive_commands.has(chat_command):
+		interactive_commands[chat_command]
+		interactive_commands.erase(chat_command)
 
 # Events
-func _on_message_recieved(sender: String, text: String, emotes: Array) -> void:
-    var input_cmd: Array = text.split(' ')
+func _on_message_recieved(sender: String, text: String, emotes: Array, attrs: Dictionary) -> void:
+	var input_cmd: Array = text.split(' ')
 
-    for cmd in interactive_commands:
-        if input_cmd[0] == cmd:
+	for cmd in interactive_commands:
+		if input_cmd[0] == cmd:
 
-            if not interactive_commands[cmd].variable_params_count \
-            and input_cmd.size() - 1 < interactive_commands[cmd].params_count:
-                # TODO: React to invalid command params in chat
-                return
+			if not interactive_commands[cmd].variable_params_count \
+			and input_cmd.size() - 1 < interactive_commands[cmd].params_count:
+				# TODO: React to invalid command params in chat
+				return
 
-            var params: Array = [sender]
-            var params_count: int = clamp(
-                input_cmd.size() - 1,
-                0,
-                interactive_commands[cmd].params_count
-            )
+			var params: Array = [sender]
+			var params_count: int = clamp(
+				input_cmd.size() - 1,
+				0,
+				interactive_commands[cmd].params_count
+			)
 
-            if params_count >= 1:
-                for i in range(params_count):
-                    params.append(input_cmd[i + 1])
+			if params_count >= 1:
+				for i in range(params_count):
+					params.append(input_cmd[i + 1])
 
-            interactive_commands[cmd].call_command(params)
+			params.append(attrs)
+
+			interactive_commands[cmd].call_command(params)

--- a/addons/godot-twicil/helpers/twitch_message_wrapper.gd
+++ b/addons/godot-twicil/helpers/twitch_message_wrapper.gd
@@ -3,8 +3,8 @@ class_name TwitchMessage
 enum EmoteType {TWITCH, BTTV, FFZ}
 
 const emote_id_methods = {
-    EmoteType.BTTV: '__get_bttv_emote_id',
-    EmoteType.FFZ: '__get_ffz_emote_id'
+	EmoteType.BTTV: '__get_bttv_emote_id',
+	EmoteType.FFZ: '__get_ffz_emote_id'
 }
 
 
@@ -12,77 +12,80 @@ var chat_message: IrcChatMessage
 #[
 #    {
 #        'code': 'emote_code',
-#        'id': 'emote_id'
-#        'type': 0    # EmoteType enum
+#        'id': 'emote_id',
+#        'type': 0    # EmoteType enum,
+#		 'attrs': {'id':'123456-fake-id', 'subscriber':'1'}
 #    },
 #    ...
 #]
 #
 var emotes: Array
+var attrs = {}
 
 
-func _init(server_irc_message: TwitchIrcServerMessage, bttv_emotes: Dictionary, ffz_emotes):
-    chat_message = MessageWrapper.wrap(server_irc_message)
+func _init(server_irc_message: TwitchIrcServerMessage, bttv_emotes: Dictionary, ffz_emotes, message_attrs: Dictionary):
+	chat_message = MessageWrapper.wrap(server_irc_message)
+	attrs = message_attrs
 
-    emotes.clear()
+	emotes.clear()
 
-    __parse_twitch_emotes(server_irc_message.message_prefix)
-    __parse_bttv_emotes(bttv_emotes)
-    __parse_ffz_emotes(ffz_emotes)
+	__parse_twitch_emotes(server_irc_message.message_prefix)
+	__parse_bttv_emotes(bttv_emotes)
+	__parse_ffz_emotes(ffz_emotes)
 
 
 # private
 func __parse_twitch_emotes(message_prefix: String):
-    var prefix_params := message_prefix.split(';', false)
-    var emotes_param: String
+	var prefix_params := message_prefix.split(';', false)
+	var emotes_param: String
 
-    for param in prefix_params:
-        if (param as String).begins_with('emotes'):
-            var emotes_prefix_param: Array = (param as String).split('=', false, 1)
+	for param in prefix_params:
+		if (param as String).begins_with('emotes'):
+			var emotes_prefix_param: Array = (param as String).split('=', false, 1)
 
-            if emotes_prefix_param.size() <= 1:
-                return
+			if emotes_prefix_param.size() <= 1:
+				return
 
-            emotes_param = emotes_prefix_param[1]
+			emotes_param = emotes_prefix_param[1]
 
-            for emote in emotes_param.split('/', false):
-                var emote_data: Array = emote.split(':', false)
-                var id := int(emote_data[0])
+			for emote in emotes_param.split('/', false):
+				var emote_data: Array = emote.split(':', false)
+				var id := int(emote_data[0])
 
-                var positions: Array = emote_data[1].split(',', false)[0].split('-', false)
+				var positions: Array = emote_data[1].split(',', false)[0].split('-', false)
 
-                var start := int(positions[0])
-                var end := int(positions[1])
+				var start := int(positions[0])
+				var end := int(positions[1])
 
-                var code: String = chat_message.text.substr(start, end - start + 1)
+				var code: String = chat_message.text.substr(start, end - start + 1)
 
-                emotes.append({
-                    'id': id,
-                    'code': code,
-                    'type': EmoteType.TWITCH
-                })
+				emotes.append({
+					'id': id,
+					'code': code,
+					'type': EmoteType.TWITCH
+				})
 
 static func __get_bttv_emote_id(available_emotes: Dictionary, emote_code: String):
-    return available_emotes.get(emote_code)
+	return available_emotes.get(emote_code)
 
 static func __get_ffz_emote_id(available_emotes: Dictionary, emote_code: String):
-    return available_emotes.get(emote_code, {}).get('id')
+	return available_emotes.get(emote_code, {}).get('id')
 
 func __parse_emotes(available_emotes: Dictionary, type: int) -> void:
-    var message: String = ' ' + chat_message.text + ' '
+	var message: String = ' ' + chat_message.text + ' '
 
-    for emote_code in available_emotes:
-        var parse_emote_code: String = ' ' + emote_code + ' '
+	for emote_code in available_emotes:
+		var parse_emote_code: String = ' ' + emote_code + ' '
 
-        if message.find(parse_emote_code) >= 0:
-            emotes.append({
-                'id': callv(emote_id_methods.get(type), [available_emotes, emote_code]),
-                'code': emote_code,
-                'type': type
-            })
+		if message.find(parse_emote_code) >= 0:
+			emotes.append({
+				'id': callv(emote_id_methods.get(type), [available_emotes, emote_code]),
+				'code': emote_code,
+				'type': type
+			})
 
 func __parse_bttv_emotes(available_emotes: Dictionary) -> void:
-    __parse_emotes(available_emotes, EmoteType.BTTV)
+	__parse_emotes(available_emotes, EmoteType.BTTV)
 
 func __parse_ffz_emotes(available_emotes: Dictionary) -> void:
-    __parse_emotes(available_emotes, EmoteType.FFZ)
+	__parse_emotes(available_emotes, EmoteType.FFZ)

--- a/addons/godot-twicil/helpers/twitch_message_wrapper.gd
+++ b/addons/godot-twicil/helpers/twitch_message_wrapper.gd
@@ -3,8 +3,8 @@ class_name TwitchMessage
 enum EmoteType {TWITCH, BTTV, FFZ}
 
 const emote_id_methods = {
-	EmoteType.BTTV: '__get_bttv_emote_id',
-	EmoteType.FFZ: '__get_ffz_emote_id'
+    EmoteType.BTTV: '__get_bttv_emote_id',
+    EmoteType.FFZ: '__get_ffz_emote_id'
 }
 
 
@@ -14,7 +14,7 @@ var chat_message: IrcChatMessage
 #        'code': 'emote_code',
 #        'id': 'emote_id',
 #        'type': 0    # EmoteType enum,
-#		 'attrs': {'id':'123456-fake-id', 'subscriber':'1'}
+#         'attrs': {'id':'123456-fake-id', 'subscriber':'1'}
 #    },
 #    ...
 #]
@@ -24,68 +24,68 @@ var attrs = {}
 
 
 func _init(server_irc_message: TwitchIrcServerMessage, bttv_emotes: Dictionary, ffz_emotes, message_attrs: Dictionary):
-	chat_message = MessageWrapper.wrap(server_irc_message)
-	attrs = message_attrs
+    chat_message = MessageWrapper.wrap(server_irc_message)
+    attrs = message_attrs
 
-	emotes.clear()
+    emotes.clear()
 
-	__parse_twitch_emotes(server_irc_message.message_prefix)
-	__parse_bttv_emotes(bttv_emotes)
-	__parse_ffz_emotes(ffz_emotes)
+    __parse_twitch_emotes(server_irc_message.message_prefix)
+    __parse_bttv_emotes(bttv_emotes)
+    __parse_ffz_emotes(ffz_emotes)
 
 
 # private
 func __parse_twitch_emotes(message_prefix: String):
-	var prefix_params := message_prefix.split(';', false)
-	var emotes_param: String
+    var prefix_params := message_prefix.split(';', false)
+    var emotes_param: String
 
-	for param in prefix_params:
-		if (param as String).begins_with('emotes'):
-			var emotes_prefix_param: Array = (param as String).split('=', false, 1)
+    for param in prefix_params:
+        if (param as String).begins_with('emotes'):
+            var emotes_prefix_param: Array = (param as String).split('=', false, 1)
 
-			if emotes_prefix_param.size() <= 1:
-				return
+            if emotes_prefix_param.size() <= 1:
+                return
 
-			emotes_param = emotes_prefix_param[1]
+            emotes_param = emotes_prefix_param[1]
 
-			for emote in emotes_param.split('/', false):
-				var emote_data: Array = emote.split(':', false)
-				var id := int(emote_data[0])
+            for emote in emotes_param.split('/', false):
+                var emote_data: Array = emote.split(':', false)
+                var id := int(emote_data[0])
 
-				var positions: Array = emote_data[1].split(',', false)[0].split('-', false)
+                var positions: Array = emote_data[1].split(',', false)[0].split('-', false)
 
-				var start := int(positions[0])
-				var end := int(positions[1])
+                var start := int(positions[0])
+                var end := int(positions[1])
 
-				var code: String = chat_message.text.substr(start, end - start + 1)
+                var code: String = chat_message.text.substr(start, end - start + 1)
 
-				emotes.append({
-					'id': id,
-					'code': code,
-					'type': EmoteType.TWITCH
-				})
+                emotes.append({
+                    'id': id,
+                    'code': code,
+                    'type': EmoteType.TWITCH
+                })
 
 static func __get_bttv_emote_id(available_emotes: Dictionary, emote_code: String):
-	return available_emotes.get(emote_code)
+    return available_emotes.get(emote_code)
 
 static func __get_ffz_emote_id(available_emotes: Dictionary, emote_code: String):
-	return available_emotes.get(emote_code, {}).get('id')
+    return available_emotes.get(emote_code, {}).get('id')
 
 func __parse_emotes(available_emotes: Dictionary, type: int) -> void:
-	var message: String = ' ' + chat_message.text + ' '
+    var message: String = ' ' + chat_message.text + ' '
 
-	for emote_code in available_emotes:
-		var parse_emote_code: String = ' ' + emote_code + ' '
+    for emote_code in available_emotes:
+        var parse_emote_code: String = ' ' + emote_code + ' '
 
-		if message.find(parse_emote_code) >= 0:
-			emotes.append({
-				'id': callv(emote_id_methods.get(type), [available_emotes, emote_code]),
-				'code': emote_code,
-				'type': type
-			})
+        if message.find(parse_emote_code) >= 0:
+            emotes.append({
+                'id': callv(emote_id_methods.get(type), [available_emotes, emote_code]),
+                'code': emote_code,
+                'type': type
+            })
 
 func __parse_bttv_emotes(available_emotes: Dictionary) -> void:
-	__parse_emotes(available_emotes, EmoteType.BTTV)
+    __parse_emotes(available_emotes, EmoteType.BTTV)
 
 func __parse_ffz_emotes(available_emotes: Dictionary) -> void:
-	__parse_emotes(available_emotes, EmoteType.FFZ)
+    __parse_emotes(available_emotes, EmoteType.FFZ)


### PR DESCRIPTION
This adds the attributes that twitch sends on the response as the last parameter in params always. This way the game can decide to let only moderators use a command, or save data with a user-id.